### PR TITLE
Added become/resign first responder

### DIFF
--- a/CDAlertView/Classes/CDAlertView.swift
+++ b/CDAlertView/Classes/CDAlertView.swift
@@ -320,6 +320,18 @@ open class CDAlertView: UIView {
     public func add(action: CDAlertViewAction) {
         actions.append(action)
     }
+    
+    public func textFieldBecomeFirstResponder() {
+        if !isTextFieldHidden {
+            textField.becomeFirstResponder()
+        }
+    }
+    
+    public func textFieldResignFirstResponder() {
+        if !isTextFieldHidden {
+            textField.resignFirstResponder()
+        }
+    }
 
     open override func touchesEnded(_ touches: Set<UITouch>,
                                     with event: UIEvent?) {


### PR DESCRIPTION
I ended up using longer method names because there was a collision with the Obj-C becomeFirstResponder method—not sure if this is your preferred nomenclature or not