### PR TITLE
% Fixed Swift Version in Xcode project

### DIFF
--- a/CDAlertView.xcodeproj/project.pbxproj
+++ b/CDAlertView.xcodeproj/project.pbxproj
@@ -484,7 +484,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -503,7 +503,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.candostdagdeviren.CDAlertView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The project file specified Swift 4.0, but uses Swift 4.2 syntax so this doesn't compile.