### PR TITLE
Hide option: the backgroundView tap

### DIFF
--- a/CDAlertView/Classes/CDAlertView.swift
+++ b/CDAlertView/Classes/CDAlertView.swift
@@ -185,6 +185,8 @@ open class CDAlertView: UIView {
 
     public var customView: UIView?
 
+    public var canHideWhenTapBack = false
+
     public var hideAnimations: CDAlertAnimationBlock?
 
     public var hideAnimationDuration: TimeInterval = 0.5
@@ -393,7 +395,7 @@ open class CDAlertView: UIView {
 
     open override func touchesEnded(_ touches: Set<UITouch>,
                                     with event: UIEvent?) {
-        if actions.count == 0 {
+        if actions.count == 0 || canHideWhenTapBack {
             touches.forEach { (touch) in
                 if touch.view == self.backgroundView {
                     self.hide(animations: self.hideAnimations, isPopupAnimated: true)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ alert.autoHideTime = 4.5 // This will hide alert box after 4.5 seconds
 
 `isActionButtonsVertical: Bool` -> Alignes action buttons vertical. Default is `false`. Maximum number of horizontal buttons is 3.
 
+`canHideWhenTapBack` -> Hide self when tapped backgroundView. Default is `false`. 
+
 `hideAnimationDuration: TimeInterval` -> Sets the animation duration of hide animation
 
 `hideAnimations: CDAlertAnimationBlock` -> Sets the hiding animations depending on the `center`, `transform` and `alpha` values. You can create your animations by changing these values for alert popup.


### PR DESCRIPTION
added property: canHideWhenBackTap in README.md, CDAlertView.swift

Hide self when tapped backgroundView. Default is `false`. 